### PR TITLE
Add support for time being in the format "hh:mm"

### DIFF
--- a/src/timepro_timesheet/__init__.py
+++ b/src/timepro_timesheet/__init__.py
@@ -1,4 +1,3 @@
 from .version import __version__
 
-
 __all__ = ['__version__']

--- a/src/timepro_timesheet/api.py
+++ b/src/timepro_timesheet/api.py
@@ -1,13 +1,13 @@
 import re
-from datetime import datetime, date, timedelta
+from datetime import date
 
 from dateutil.relativedelta import relativedelta, MO, FR
 from requests_html import HTMLSession
 
 from .timesheet import Timesheet
 
-
 TODAY = date.today()
+
 
 class LoginError(Exception):
     pass

--- a/src/timepro_timesheet/cli.py
+++ b/src/timepro_timesheet/cli.py
@@ -1,6 +1,6 @@
-import sys
-import json
 import argparse
+import json
+import sys
 from datetime import date
 
 from dateutil.parser import parse as dateparser
@@ -9,15 +9,13 @@ from dateutil.relativedelta import relativedelta, MO, FR
 from .api import TimesheetAPI
 from .timesheet import Timesheet
 
-
 TODAY = date.today()
 
 
 class TimesheetCLI:
-
     def __init__(self):
         parser = argparse.ArgumentParser(
-            description='Programmatically get your timesheet from Intertec TimePro (timesheets.com.au.')
+            description='Programmatically get your timesheet from Intertec TimePro (timesheets.com.au.)')
         parser.add_argument('command', help='Action to run')
         # parse only common arguments, the rest will be parsed per subcommand
         args = parser.parse_args(sys.argv[1:2])
@@ -31,21 +29,29 @@ class TimesheetCLI:
     def _create_parser(self, description):
         parser = argparse.ArgumentParser(description=description)
         login_parameters = parser.add_argument_group('login parameters')
-        login_parameters.add_argument('-c', '--customer', dest='customer', required=True, help="Employer's TimePro Customer ID")
-        login_parameters.add_argument('-u', '--user', dest='username', required=True, help='Username to log into TimePro')
-        login_parameters.add_argument('-p', '--password', dest='password', required=True, help='Password to log into TimePro')
+        login_parameters.add_argument('-c', '--customer', dest='customer', required=True,
+                                      help="Employer's TimePro Customer ID")
+        login_parameters.add_argument('-u', '--user', dest='username', required=True,
+                                      help='Username to log into TimePro')
+        login_parameters.add_argument('-p', '--password', dest='password', required=True,
+                                      help='Password to log into TimePro')
         return parser
 
     def get(self, arg_options):
         parser = self._create_parser(
             description='Get timesheet data from Intertec TimePro')
         get_parameters = parser.add_argument_group('filter options')
-        get_parameters.add_argument('--start', dest='start_date', metavar='START_DATE', help='Start date of timesheet period')
+        get_parameters.add_argument('--start', dest='start_date', metavar='START_DATE',
+                                    help='Start date of timesheet period')
         get_parameters.add_argument('--end', dest='end_date', metavar='END_DATE', help='End date of timesheet period')
-        get_parameters.add_argument('--current-week', dest='current_week', action='store_true', help="Get current week's timesheet")
-        get_parameters.add_argument('--current-month', dest='current_month', action='store_true', help="Get current month's timesheet")
-        get_parameters.add_argument('--last-week', dest='last_week', action='store_true', help="Get last week's timesheet")
-        get_parameters.add_argument('--last-month', dest='last_month', action='store_true', help="Get last month's timesheet")
+        get_parameters.add_argument('--current-week', dest='current_week', action='store_true',
+                                    help="Get current week's timesheet")
+        get_parameters.add_argument('--current-month', dest='current_month', action='store_true',
+                                    help="Get current month's timesheet")
+        get_parameters.add_argument('--last-week', dest='last_week', action='store_true',
+                                    help="Get last week's timesheet")
+        get_parameters.add_argument('--last-month', dest='last_month', action='store_true',
+                                    help="Get last month's timesheet")
 
         # If Saturday or Sunday, treat "last week" as the week just been
         week_offset = 1 if TODAY.weekday() >= 5 else 0

--- a/src/timepro_timesheet/timesheet.py
+++ b/src/timepro_timesheet/timesheet.py
@@ -1,12 +1,10 @@
-import re
 import itertools
 import json
-from collections import OrderedDict
-from datetime import timedelta
+import re
 
 from dateutil.parser import parse as dateparser
 
-from .utils import generate_date_series, convert_keys_to_dates
+from .utils import generate_date_series, convert_keys_to_dates, convert_time_string_and_minutes_to_hours
 
 
 class Timesheet:
@@ -75,7 +73,7 @@ class Timesheet:
                 entry['descriptions'] = descriptions
             elif entry_type == 'FinishTime':
                 times = entry.get('times', [])
-                hours = float(v) if v != '' else 0
+                hours = convert_time_string_and_minutes_to_hours(v) if v != '' else 0
                 times.append((column_id, hours))
                 entry['times'] = times
             entries[row_id] = entry
@@ -258,7 +256,7 @@ class Timesheet:
             # Lookup row
             row_entry = self.row_entries().get(row_id)
 
-            entry = {'hours': float(v) if v != '' else 0}
+            entry = {'hours': convert_time_string_and_minutes_to_hours(v) if v != '' else 0}
 
             # Check description list is populated (missing/empty when reading historical timesheets)
             descriptions = row_entry.get('descriptions')

--- a/src/timepro_timesheet/utils.py
+++ b/src/timepro_timesheet/utils.py
@@ -19,3 +19,20 @@ def convert_keys_to_dates(data):
             key = dateparser(key)
         converted_data[key] = d
     return converted_data
+
+
+def convert_time_string_and_minutes_to_hours(time_string):
+    colon_count = time_string.count(':')
+
+    if colon_count < 1:
+        return float(time_string)
+    elif colon_count > 1:
+        raise ValueError(
+            'expected time_string to be in the format hh:mm or hh.h; got {}'.format(
+                repr(time_string)
+            )
+        )
+
+    hours, minutes = [float(x) for x in time_string.split(':')]
+
+    return hours + (minutes / 60)

--- a/src/timepro_timesheet/version.py
+++ b/src/timepro_timesheet/version.py
@@ -1,6 +1,5 @@
 from pkg_resources import get_distribution, DistributionNotFound
 
-
 try:
     __version__ = get_distribution('timepro-timesheet').version
 except DistributionNotFound:

--- a/tests/test_timesheet.py
+++ b/tests/test_timesheet.py
@@ -1,7 +1,16 @@
-import pytest
-
-from timepro_timesheet.timesheet import Timesheet
+from timepro_timesheet.utils import convert_time_string_and_minutes_to_hours
 
 
-def test_placeholder():
-    assert True
+def test_convert_time_string_and_minutes_to_hours():
+    assert convert_time_string_and_minutes_to_hours('13') == 13.0
+    assert convert_time_string_and_minutes_to_hours('13:00') == 13.0
+    assert convert_time_string_and_minutes_to_hours('13.5') == 13.5
+    assert convert_time_string_and_minutes_to_hours('13:30') == 13.5
+
+    exception = None
+    try:
+        convert_time_string_and_minutes_to_hours('13:30:30')
+    except Exception as e:
+        exception = e
+
+    assert isinstance(exception, ValueError)


### PR DESCRIPTION
Hi Chris,

Hope you're going well.

Stumbled across your repo while Googling for a TimePro API- really awesome work.

The company I work seems to have their time in "hh:mm" and it was breaking some of the parsing. I didn't really dig too deep, just added support for it.

You'll notice a few files were changed- that's just PyCharm's "reformat code" and "optimize imports" features.

Lemme know if you want me to change anything in the PR.

Regards,

Ed